### PR TITLE
fix(media__heading): set spacing and size of media__heading

### DIFF
--- a/components/collections/tn-media-column.scss
+++ b/components/collections/tn-media-column.scss
@@ -20,7 +20,7 @@
  *  <p class="tn-h2">Image and text</p>
  *  <div class="tn-media-column">
  *    <div class="tn-media">
- *      <p class="tn-h3 tn-media__heading">Lorem ipsum</p>
+ *      <p class="tn-media__heading">Lorem ipsum</p>
  *      <div class="tn-media__content"><p class="tn-p">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pretium tristique ex. Nam eget arcu sit amet nisi porttitor accumsan. Nunc gravida commodo tortor, id interdum est interdum viverra. Nulla in vehicula nunc. Cras ac eros id nibh laoreet congue. Cras et varius mauris. Nulla ex enim, dapibus nec tempor sed, eleifend et sapien. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p></div>
  *    </div>
  *    <div class="tn-media">
@@ -37,7 +37,7 @@
  *      <p class="tn-media__caption">Media caption.</p>
  *    </div>
  *    <div class="tn-media">
- *      <p class="tn-h3 tn-media__heading">Lorem ipsum</p>
+ *      <p class="tn-media__heading">Lorem ipsum</p>
  *      <div class="tn-media__content"><p class="tn-p">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pretium tristique ex. Nam eget arcu sit amet nisi porttitor accumsan.</p></div>
  *    </div>
  *    <div class="tn-media">
@@ -46,7 +46,7 @@
  *    </div>
  *    <div class="tn-media">
  *      <img class="tn-media__image" src="//placehold.it/1280x720" alt="tn-media__image" />
- *      <p class="tn-h3 tn-media__heading">Lorem ipsum</p>
+ *      <p class="tn-media__heading">Lorem ipsum</p>
  *      <div class="tn-media__content"><p class="tn-p">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pretium tristique ex. Nam eget arcu sit amet nisi porttitor accumsan. </p></div>
  *    </div>
  *  </div>

--- a/components/collections/tn-media-column.scss
+++ b/components/collections/tn-media-column.scss
@@ -6,7 +6,7 @@
  * @description
  *  A column of evenly sized media elements.
  * @markup
- *  <p class="tn-h2">Two images with captions</p>
+ *  <h2 class="tn-h2">Two images with captions</h2>
  *  <div class="tn-media-column">
  *    <div class="tn-media">
  *      <img class="tn-media__image" src="//placehold.it/1280x720" alt="tn-media__image" />
@@ -17,17 +17,17 @@
  *      <p class="tn-media__caption">Placeholder image.</p>
  *    </div>
  *  </div>
- *  <p class="tn-h2">Image and text</p>
+ *  <h2 class="tn-h2">Image and text</h2>
  *  <div class="tn-media-column">
  *    <div class="tn-media">
- *      <p class="tn-media__heading">Lorem ipsum</p>
+ *      <h3 class="tn-media__heading">Lorem ipsum</h3>
  *      <div class="tn-media__content"><p class="tn-p">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pretium tristique ex. Nam eget arcu sit amet nisi porttitor accumsan. Nunc gravida commodo tortor, id interdum est interdum viverra. Nulla in vehicula nunc. Cras ac eros id nibh laoreet congue. Cras et varius mauris. Nulla ex enim, dapibus nec tempor sed, eleifend et sapien. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p></div>
  *    </div>
  *    <div class="tn-media">
  *      <img class="tn-media__image" src="//placehold.it/1024x1024" alt="tn-media__image" />
  *    </div>
  *  </div>
- *  <p class="tn-h2">Variety column</p>
+ *  <h2 class="tn-h2">Variety column</h2>
  *  <div class="tn-media-column">
  *    <div class="tn-media">
  *      <img class="tn-media__image" src="//placehold.it/1280x720" alt="tn-media__image" />
@@ -37,7 +37,7 @@
  *      <p class="tn-media__caption">Media caption.</p>
  *    </div>
  *    <div class="tn-media">
- *      <p class="tn-media__heading">Lorem ipsum</p>
+ *      <h3 class="tn-media__heading">Lorem ipsum</p>
  *      <div class="tn-media__content"><p class="tn-p">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pretium tristique ex. Nam eget arcu sit amet nisi porttitor accumsan.</p></div>
  *    </div>
  *    <div class="tn-media">
@@ -46,7 +46,7 @@
  *    </div>
  *    <div class="tn-media">
  *      <img class="tn-media__image" src="//placehold.it/1280x720" alt="tn-media__image" />
- *      <p class="tn-media__heading">Lorem ipsum</p>
+ *      <h3 class="tn-media__heading">Lorem ipsum</h3>
  *      <div class="tn-media__content"><p class="tn-p">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam pretium tristique ex. Nam eget arcu sit amet nisi porttitor accumsan. </p></div>
  *    </div>
  *  </div>

--- a/components/elements/tn-media-mixins.scss
+++ b/components/elements/tn-media-mixins.scss
@@ -1,3 +1,5 @@
+@import "../typography/tn-headings-mixins";
+@import "../_variables/typography";
 @import "../_variables/sizes";
 
 @mixin tn-media {
@@ -5,6 +7,8 @@
 }
 
 @mixin tn-media__heading {
+  @include tn-heading($tn-font-size--h3);
+
   margin: $tn-spacing--standard-element-nonbordered 0;
 }
 

--- a/components/elements/tn-media.scss
+++ b/components/elements/tn-media.scss
@@ -1,5 +1,4 @@
 @import "tn-media-mixins";
-@import "../typography/tn-p-mixins";
 
 /**
  * @molecule Media
@@ -11,9 +10,9 @@
  *  <ul>
  *   <li><strong>tn-media:</strong> main class
  *     <ul>
- *       <li><strong>tn-media__heading:</strong> media heading. Best used alongside a heading class like tn-h2.</li>
+ *       <li><strong>tn-media__heading:</strong> media heading.</li>
  *       <li><strong>tn-media__image:</strong> an image that spans the width of the media element and retains its aspect ratio.</li>
- *       <li><strong>tn-media__caption:</strong> centered text. </li>
+ *       <li><strong>tn-media__caption:</strong> centered text.</li>
  *       <li><strong>tn-media__content:</strong> genral-purpose container for any other element.</li>
  *      </ul>
  *   </li>


### PR DESCRIPTION
The merging of heading styles and the media element did not work out quite like I'd expected, and the `media__heading` did not override the `tn-h*` margin.

Instead of fixing the override I'd like to suggest this change making `tn-media_heading` a standalone class (not to be used with a `tn-h*` class).

If someone would like to use a heading with a size other than `$tn-font-size--h3` in a media element they can just use a `tn-media__content` wrapper around any heading.